### PR TITLE
Feature: changed basebox to vstone boxes on vagrantcloud

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -5,7 +5,7 @@ Vagrant::Config.run do |config|
 
   config.vm.define :default do |default_config|
 
-       default_config.vm.box = "Centos64-Vstone"
+       default_config.vm.box = "vStone/centos-6.x-puppet.3.x"
        default_config.vm.network  :hostonly, "10.42.42.20" # change for reasons was 51
        default_config.vm.share_folder "PuppetFiles", "/etc/puppet/files", "puppet-files"
 
@@ -13,8 +13,8 @@ Vagrant::Config.run do |config|
        default_config.vm.host_name = "logstash"
 
        default_config.vm.forward_port  80, 8082 # for Apache
-       default_config.vm.forward_port  9200, 9200 # for Kibana3 
-       default_config.vm.forward_port  3355, 3355 # for Kibana3               
+       default_config.vm.forward_port  9200, 9200 # for Kibana3
+       default_config.vm.forward_port  3355, 3355 # for Kibana3
 
        default_config.vm.provision :puppet do |default_puppet|
        		default_puppet.manifests_path = "manifests"


### PR DESCRIPTION
That way the box becomes abstrat and everyone can benefit of your vagrant setup without the need of preinstalling the vagrant box.

So on a vagrant up the box will be downloaded automagically from vagrantcloud :)
